### PR TITLE
Remove encoding for compatibility with Python 3.6

### DIFF
--- a/pytrafik/client.py
+++ b/pytrafik/client.py
@@ -104,6 +104,6 @@ class Client:
 		res = requests.get(url, headers=headers)
 		print (url)
 		if res.status_code == 200:
-			return json.loads(res.content.decode('UTF-8'), 'UTF-8')
+			return json.loads(res.content.decode('UTF-8'))
 		else:
 			raise Exception('Error: ' + str(res.status_code) + str(res.content))


### PR DESCRIPTION
As per Python 3.6 or higher, passing encoding as an unnamed argument is no longer supported.
Since the argument itself has been [ignored and deprecated](https://docs.python.org/3.6/library/json.html#json.loads) for a while, I guess it makes little sense to keep it there. :smile: :+1: 